### PR TITLE
#933 set accepted to false if user gets blocked

### DIFF
--- a/apps/backend/src/features/api/api.service.ts
+++ b/apps/backend/src/features/api/api.service.ts
@@ -605,4 +605,13 @@ export class ApiService {
             return;
         }
     }
+
+    async setContactAccepted(userId: string, location: string, accepted: boolean) {
+        const destinationUrl = `http://[${location}]/api/v2/contacts/${accepted}/${userId}`;
+        try {
+            return (await axios.put<boolean>(destinationUrl)).data;
+        } catch (error) {
+            return;
+        }
+    }
 }

--- a/apps/backend/src/features/blocked-contact/blocked-contact.module.ts
+++ b/apps/backend/src/features/blocked-contact/blocked-contact.module.ts
@@ -7,9 +7,18 @@ import { YggdrasilModule } from '../yggdrasil/yggdrasil.module';
 import { BlockedContactController } from './blocked-contact.controller';
 import { BlockedContactService } from './blocked-contact.service';
 import { BlockedContactRedisRepository } from './repositories/blocked-contact-redis.repository';
+import { ApiModule } from '../api/api.module';
+import { ContactModule } from '../contact/contact.module';
 
 @Module({
-    imports: [DbModule, forwardRef(() => YggdrasilModule), KeyModule, EncryptionModule],
+    imports: [
+        DbModule,
+        forwardRef(() => YggdrasilModule),
+        forwardRef(() => ApiModule),
+        forwardRef(() => ContactModule),
+        KeyModule,
+        EncryptionModule,
+    ],
     controllers: [BlockedContactController],
     providers: [BlockedContactService, BlockedContactRedisRepository],
     exports: [BlockedContactService],

--- a/apps/backend/src/features/chat/chat.service.ts
+++ b/apps/backend/src/features/chat/chat.service.ts
@@ -33,6 +33,7 @@ export class ChatService {
         private readonly _keyService: KeyService,
         @Inject(forwardRef(() => ChatGateway))
         private readonly _chatGateway: ChatGateway,
+        @Inject(forwardRef(() => BlockedContactService))
         private readonly _blockedContactService: BlockedContactService
     ) {}
 

--- a/apps/backend/src/features/contact/contact.controller.ts
+++ b/apps/backend/src/features/contact/contact.controller.ts
@@ -42,4 +42,14 @@ export class ContactController {
             containerOffline: false,
         });
     }
+
+    @Put(':accepted/:userId')
+    async setContactAccepted(@Param() { userId, accepted }: { userId: string; accepted: string }): Promise<Contact> {
+        return await this._contactService.updateContact({
+            id: userId,
+            contactRequest: false,
+            accepted: accepted === 'true',
+            containerOffline: false,
+        });
+    }
 }

--- a/apps/backend/src/features/contact/contact.service.ts
+++ b/apps/backend/src/features/contact/contact.service.ts
@@ -27,6 +27,7 @@ export class ContactService {
         private readonly _apiService: ApiService,
         @Inject(forwardRef(() => ChatService))
         private readonly _chatService: ChatService,
+        @Inject(forwardRef(() => BlockedContactService))
         private readonly _blockedContactService: BlockedContactService,
         @Inject(forwardRef(() => ChatGateway))
         private readonly _chatGateway: ChatGateway
@@ -297,6 +298,17 @@ export class ContactService {
         contact.contactRequest = contactRequest;
         contact.accepted = accepted;
         contact.containerOffline = containerOffline;
+        try {
+            return await this._contactRepo.updateContact({ contact });
+        } catch (error) {
+            throw new BadRequestException(`unable to update contact: ${error}`);
+        }
+    }
+
+    async setContactAccepted(id: string, accepted: boolean): Promise<Contact> {
+        const contact = await this.getContact({ id });
+        if (!contact) return;
+        contact.accepted = accepted;
         try {
             return await this._contactRepo.updateContact({ contact });
         } catch (error) {

--- a/apps/backend/src/features/post/post.service.ts
+++ b/apps/backend/src/features/post/post.service.ts
@@ -112,9 +112,6 @@ export class PostService {
 
                 await Promise.all(
                     contacts.map(async contact => {
-                        const blockedByContact = await this._apiService.checkIfBlocked(username, contact.location);
-                        if (blockedByContact) return;
-
                         const data = await this._apiService.getExternalPosts({
                             location: contact.location,
                             userId: contact.id,


### PR DESCRIPTION
The previous fix that checked if a user was blocked by the contact before getting all posts was way to slow.

So now if a user gets blocked the accepted property of the contact gets set to false. And all contacts get filtered out if they are not accepted.