### PR TITLE
#969 don't filter share on 'isSharedWithMe'

### DIFF
--- a/apps/backend/src/features/quantum/repositories/share-redis.repository.ts
+++ b/apps/backend/src/features/quantum/repositories/share-redis.repository.ts
@@ -79,7 +79,7 @@ export class ShareRedisRepository extends EntityRepository<Share> {
      * @return {Chat} - Found share.
      */
     async getShareByPath({ path }: { path: string }): Promise<Share> {
-        return await this.findOneAnd({ where: 'path', eq: path, and: 'isSharedWithMe', andEq: false });
+        return await this.findOne({ where: 'path', eq: path });
     }
 
     async updateShare({ share }: { share: Share }): Promise<Share> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10500,6 +10500,11 @@ pstree.remy@^1.1.8:
   resolved "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
+pull-refresh-vue3@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pull-refresh-vue3/-/pull-refresh-vue3-0.3.1.tgz#e75ffad5d71e30a85b5338f2beca9fc8a1e01432"
+  integrity sha512-DTcosG4LT3dGF/amzMP3YOwQ11x1taxQU3ChGx2SDCT5LMmyNpUD7pb2FAZkB/QEHVSpUTIfCcanfXANkYOXjw==
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz"


### PR DESCRIPTION
Sharing the same file with multiple groups created a new share in redis every time. While it should have been just 1 share for each file with multiple permissions. See picture with example share:
![image](https://user-images.githubusercontent.com/36887810/218860054-0b3afe84-5df8-4abe-8c2d-c8c0998b0f2f.png)


This was because the backend checked every time if the share already exists. If it exists it adds the permissions to the existing share, other wise it creates a new one. 
Because 'getShareByPath' also filtered out shares if 'isSharedWithMe' was true, it returned undefined instead of the existing share. So a new share was created every time.